### PR TITLE
Fixed updateQtable to divide floats

### DIFF
--- a/ipython-notebooks/rlpart2.ipynb
+++ b/ipython-notebooks/rlpart2.ipynb
@@ -341,7 +341,7 @@
     "#This recalculates the average rewards for our Q-value look-up table\n",
     "def updateQtable(av_table, av_count, returns):\n",
     "    for key in returns:\n",
-    "        av_table[key] = av_table[key] + (1 / av_count[key]) * (returns[key]- av_table[key])\n",
+    "        av_table[key] = av_table[key] + (1.0 / av_count[key]) * (returns[key]- av_table[key])\n",
     "    return av_table\n",
     "        \n",
     "#returns Q-value/avg rewards for each action given a state\n",


### PR DESCRIPTION
On some environments(like mine one :D ) dividing two integers is rounded to integer. For me it caused complete mess as a result.
